### PR TITLE
Added configuration for amazon0302 graph

### DIFF
--- a/config/graphs.properties
+++ b/config/graphs.properties
@@ -1,7 +1,8 @@
 # Properties file describing the list of available graphs
 
 # Exhaustive list of available graphs to enable property discovery
-graphs.names = ldbc-1, ldbc-3, ldbc-10, ldbc-30, ldbc-100, ldbc-300, ldbc-1000
+graphs.names = ldbc-1, ldbc-3, ldbc-10, ldbc-30, ldbc-100, ldbc-300, ldbc-1000,\
+	amazon0302
 
 # Root directory containing graphs on local filesystem
 graphs.root-directory = /data/graphalytics/graphs
@@ -14,4 +15,5 @@ include = graphs/ldbc-30.properties
 include = graphs/ldbc-100.properties
 include = graphs/ldbc-300.properties
 include = graphs/ldbc-1000.properties
+include = graphs/amazon0302.properties
 

--- a/config/graphs/amazon0302.properties
+++ b/config/graphs/amazon0302.properties
@@ -1,0 +1,30 @@
+# Properties file describing the Amazon0302 dataset
+# Link: http://snap.stanford.edu/data/amazon0302.html
+
+# Filename of graph on local filesystem
+graph.amazon0302.file = amazon0302.txt
+
+# Properties describing the directivity and graph format
+graph.amazon0302.directed = true
+graph.amazon0302.edge-based = true
+
+# List of supported algorithms on the graph
+graph.amazon0302.algorithms = bfs, cd, conn, evo, stats
+
+# Per-algorithm properties describing the input parameters to each algorithm
+
+# Parameters for BFS
+graph.amazon0302.bfs.source-vertex = 99843
+
+# Parameters for CD
+graph.amazon0302.cd.node-preference = 0.1
+graph.amazon0302.cd.hop-attenuation = 0.1
+graph.amazon0302.cd.max-iterations = 21
+
+# Parameters for EVO
+graph.amazon0302.evo.max-id = 262110
+graph.amazon0302.evo.pratio = 0.5
+graph.amazon0302.evo.rratio = 0.5
+graph.amazon0302.evo.max-iterations = 6
+graph.amazon0302.evo.new-vertices = 262
+


### PR DESCRIPTION
The SNAP graphs are already in edge-based format and should thus be readable by all platforms. Do not forget to `gunzip` them.