### PR TITLE
Removed dependency on Reflections library

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,11 +11,6 @@
 	</parent>
 	<dependencies>
 		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-			<version>0.9.9</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 			<version>1.10</version>

--- a/core/src/main/java/nl/tudelft/graphalytics/Graphalytics.java
+++ b/core/src/main/java/nl/tudelft/graphalytics/Graphalytics.java
@@ -6,57 +6,75 @@ import nl.tudelft.graphalytics.domain.BenchmarkSuiteResult;
 import nl.tudelft.graphalytics.reporting.BenchmarkReport;
 import nl.tudelft.graphalytics.reporting.html.HtmlBenchmarkReportGenerator;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.reflections.Reflections;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Set;
+import java.util.Scanner;
 
 public class Graphalytics {
-	private static final Logger log = LogManager.getLogger();
+	private static final Logger LOG = LogManager.getLogger();
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws IOException {
 		// Get the first command-line argument (platform name)
 		if (args.length < 1) {
-			log.fatal("Missing argument <platform>.");
-			System.exit(1);
+			throw new GraphalyticsLoaderException("Missing argument <platform>.");
 		}
 		String platform = args[0];
 
-		// Use the Reflections library to find the Platform subclass for the given platform
-		Reflections reflections = new Reflections("nl.tudelft.graphalytics." + platform);
-		Set<Class<? extends Platform>> platformClasses = reflections.getSubTypesOf(Platform.class);
-		if (platformClasses.size() == 0) {
-			log.fatal("Cannot find a subclass of \"nl.tudelft.graphalytics.Platform\" in package \"" +
-					"nl.tudelft.graphalytics." + platform + "\".");
-			System.exit(2);
-		} else if (platformClasses.size() > 1) {
-			log.fatal("Found multiple subclasses of \"nl.tudelft.graphalytics.Platform\"" +
-					"in package \"nl.tudelft.graphalytics." + platform + "\".");
-			System.exit(3);
+		// Read the <platform>.platform file that should be in the classpath to determine which class to load
+		InputStream platformFileStream = Graphalytics.class.getResourceAsStream("/" + platform + ".platform");
+		if (platformFileStream == null) {
+			throw new GraphalyticsLoaderException("Missing resource \"" + platform + ".platform\".");
+		}
+
+		String platformClassName;
+		try (Scanner platformScanner = new Scanner(platformFileStream)) {
+			if (!platformScanner.hasNext()) {
+				throw new GraphalyticsLoaderException("Expected a single line with a class name in \"" + platform +
+						".platform\", got an empty file.");
+			}
+
+			platformClassName = platformScanner.next();
+
+			if (platformScanner.hasNext()) {
+				throw new GraphalyticsLoaderException("Expected a single line with a class name in \"" + platform +
+						".platform\", got multiple words.");
+			}
+		}
+
+		// Load the class by name
+		Class<? extends Platform> platformClass;
+		try {
+			Class<?> platformClassUncasted = Class.forName(platformClassName);
+			if (!Platform.class.isAssignableFrom(platformClassUncasted)) {
+				throw new GraphalyticsLoaderException("Expected class \"" + platformClassName +
+						"\" to be a subclass of \"nl.tudelft.graphalytics.Platform\".");
+			}
+
+			platformClass = platformClassUncasted.asSubclass(Platform.class);
+		} catch (ClassNotFoundException e) {
+			throw new GraphalyticsLoaderException("Could not find class \"" + platformClassName + "\".", e);
 		}
 
 		// Attempt to instantiate the Platform subclass to run the benchmark
-		Platform platformInstance = null;
+		Platform platformInstance;
 		try {
-			platformInstance = new ArrayList<>(platformClasses).get(0).newInstance();
+			platformInstance = platformClass.newInstance();
 		} catch (InstantiationException | IllegalAccessException e) {
-			log.catching(Level.FATAL, e);
-			System.exit(4);
+			throw new GraphalyticsLoaderException("Failed to instantiate platform class \"" +
+					platformClassName + "\".", e);
 		}
 
 		// Load the benchmark suite from the configuration files
-		BenchmarkSuite benchmarkSuite = null;
+		BenchmarkSuite benchmarkSuite;
 		try {
 			benchmarkSuite = BenchmarkSuiteLoader.readBenchmarkSuiteFromProperties();
 		} catch (InvalidConfigurationException | ConfigurationException e) {
-			log.fatal("Failed to parse benchmark configuration: ", e);
-			System.exit(5);
+			throw new GraphalyticsLoaderException("Failed to parse benchmark configuration.", e);
 		}
 
 		// Run the benchmark
@@ -70,18 +88,17 @@ public class Graphalytics {
 		try {
 			report.write(platformInstance.getName() + "-report");
 		} catch (IOException e) {
-			log.error("Failed to write report: ", e);
-			log.info("Attempting to write report to temporary directory.");
+			LOG.error("Failed to write report: ", e);
+			LOG.info("Attempting to write report to temporary directory.");
 			// Attempt to write the benchmark report to a unique temporary directory
-			Path tempDirectory = null;
+			Path tempDirectory;
 			try {
 				tempDirectory = Files.createTempDirectory(platformInstance.getName() + "-report-");
 				report.write(tempDirectory.toString());
 			} catch (IOException ex) {
-				log.fatal("Failed to write report to temporary directory: ", ex);
-				System.exit(6);
+				throw new IOException("Failed to write report to temporary directory: ", ex);
 			}
-			log.info("Wrote benchmark report to \"" + tempDirectory.toString() + "\".");
+			LOG.info("Wrote benchmark report to \"" + tempDirectory.toString() + "\".");
 		}
 	}
 

--- a/core/src/main/java/nl/tudelft/graphalytics/GraphalyticsLoaderException.java
+++ b/core/src/main/java/nl/tudelft/graphalytics/GraphalyticsLoaderException.java
@@ -1,0 +1,18 @@
+package nl.tudelft.graphalytics;
+
+/**
+ * Wrapper class for exceptions that occur during the initialization phase of Graphalytics.
+ *
+ * @author Tim Hegeman
+ */
+public class GraphalyticsLoaderException extends RuntimeException {
+
+	public GraphalyticsLoaderException(String message) {
+		super(message);
+	}
+
+	public GraphalyticsLoaderException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+}

--- a/platforms/giraph/src/main/resources/giraph.platform
+++ b/platforms/giraph/src/main/resources/giraph.platform
@@ -1,0 +1,1 @@
+nl.tudelft.graphalytics.giraph.GiraphPlatform

--- a/platforms/graphlab/src/main/resources/graphlab.platform
+++ b/platforms/graphlab/src/main/resources/graphlab.platform
@@ -1,0 +1,1 @@
+nl.tudelft.graphalytics.graphlab.GraphLabPlatform

--- a/platforms/graphx/src/main/resources/graphx.platform
+++ b/platforms/graphx/src/main/resources/graphx.platform
@@ -1,0 +1,1 @@
+nl.tudelft.graphalytics.graphx.GraphXPlatform

--- a/platforms/mapreducev2/src/main/resources/mapreducev2.platform
+++ b/platforms/mapreducev2/src/main/resources/mapreducev2.platform
@@ -1,0 +1,1 @@
+nl.tudelft.graphalytics.mapreducev2.MapReduceV2Platform

--- a/platforms/neo4j/src/main/resources/neo4j.platform
+++ b/platforms/neo4j/src/main/resources/neo4j.platform
@@ -1,0 +1,1 @@
+nl.tudelft.graphalytics.neo4j.Neo4jPlatform


### PR DESCRIPTION
The Reflections library pulled in dependencies that conflicted with the MapReduce test framework, so I decided it would be best to drop this library. It was only used for finding the `Platform` implementation to be executed by searching the `nl.tudelft.graphalytics.<platform>` package. This was not truly extensible to begin with, so I replaced it with the requirement that each platform includes in its resources a `<platform>.platform` file that contains the fully-qualified class name of the `Platform` implementation it provides.