### PR TITLE
MapReduce test fixes

### DIFF
--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/DirectedCambridgeLPAReducer.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/DirectedCambridgeLPAReducer.java
@@ -68,7 +68,7 @@ public class DirectedCambridgeLPAReducer extends MapReduceBase implements Reduce
      */
     private String[] determineLabel(Iterator<String> msgIterator, String oldLabel, Reporter reporter) {
         String[] result = new String[2]; // 0 - new label, 1 - new label score
-        float maxLabelScore = -Float.NEGATIVE_INFINITY;
+        float maxLabelScore = Float.NEGATIVE_INFINITY;
         Map<String, Float> neighboursLabels = new HashMap<String, Float>(); // key - label, value - output of EQ 2
         Map<String, Float> labelsMaxScore = new HashMap<String, Float>();   // helper struct for updating new label score
 

--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/DirectedCambridgeLPAReducer.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/DirectedCambridgeLPAReducer.java
@@ -108,11 +108,17 @@ public class DirectedCambridgeLPAReducer extends MapReduceBase implements Reduce
                 potentialLabels.add(tmpLabel);
         }
 
-        // random tie break
-        if(potentialLabels.size() > 1) {
-            int labelIndex = this.rnd.nextInt(potentialLabels.size());
-            result[0] = potentialLabels.get(labelIndex); // new label
-        }
+	    // select the smallest potential label to make output deterministic
+	    if(potentialLabels.size() > 1) {
+		    long selectedLabel = Long.parseLong(potentialLabels.get(0));
+		    for (String potentialLabel : potentialLabels) {
+			    long parsedPotentialLabel = Long.parseLong(potentialLabel);
+			    if (parsedPotentialLabel < selectedLabel) {
+				    selectedLabel = parsedPotentialLabel;
+			    }
+		    }
+		    result[0] = String.valueOf(selectedLabel); // new label
+	    }
 
         // set delta param value
         if(result[0].equals(oldLabel))

--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/DirectedCambridgeLPAReducer.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/DirectedCambridgeLPAReducer.java
@@ -68,7 +68,7 @@ public class DirectedCambridgeLPAReducer extends MapReduceBase implements Reduce
      */
     private String[] determineLabel(Iterator<String> msgIterator, String oldLabel, Reporter reporter) {
         String[] result = new String[2]; // 0 - new label, 1 - new label score
-        float maxLabelScore = -100;
+        float maxLabelScore = -Float.NEGATIVE_INFINITY;
         Map<String, Float> neighboursLabels = new HashMap<String, Float>(); // key - label, value - output of EQ 2
         Map<String, Float> labelsMaxScore = new HashMap<String, Float>();   // helper struct for updating new label score
 
@@ -108,17 +108,17 @@ public class DirectedCambridgeLPAReducer extends MapReduceBase implements Reduce
                 potentialLabels.add(tmpLabel);
         }
 
-	    // select the smallest potential label to make output deterministic
-	    if(potentialLabels.size() > 1) {
-		    long selectedLabel = Long.parseLong(potentialLabels.get(0));
-		    for (String potentialLabel : potentialLabels) {
-			    long parsedPotentialLabel = Long.parseLong(potentialLabel);
-			    if (parsedPotentialLabel < selectedLabel) {
-				    selectedLabel = parsedPotentialLabel;
-			    }
-		    }
-		    result[0] = String.valueOf(selectedLabel); // new label
-	    }
+        // select the smallest potential label to make output deterministic
+        if(potentialLabels.size() > 1) {
+            long selectedLabel = Long.parseLong(potentialLabels.get(0));
+            for (String potentialLabel : potentialLabels) {
+                long parsedPotentialLabel = Long.parseLong(potentialLabel);
+                if (parsedPotentialLabel < selectedLabel) {
+                    selectedLabel = parsedPotentialLabel;
+                }
+            }
+            result[0] = String.valueOf(selectedLabel); // new label
+        }
 
         // set delta param value
         if(result[0].equals(oldLabel))

--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/UndirectedCambridgeLPAReducer.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/UndirectedCambridgeLPAReducer.java
@@ -70,7 +70,7 @@ public class UndirectedCambridgeLPAReducer extends MapReduceBase implements Redu
     */
     private String[] determineLabel(Iterator<String> msgIterator, String oldLabel, Reporter reporter) {
         String[] result = new String[2]; // 0 - new label, 1 - new label score
-        float maxLabelScore = -100;
+        float maxLabelScore = Float.NEGATIVE_INFINITY;
         Map<String, Float> neighboursLabels = new HashMap<String, Float>(); // key - label, value - output of EQ 2
         Map<String, Float> labelsMaxScore = new HashMap<String, Float>();   // helper struct for updating new label score
 
@@ -110,10 +110,16 @@ public class UndirectedCambridgeLPAReducer extends MapReduceBase implements Redu
                 potentialLabels.add(tmpLabel);
         }
 
-        // random tie break
+        // select the smallest potential label to make output deterministic
         if(potentialLabels.size() > 1) {
-            int labelIndex = this.rnd.nextInt(potentialLabels.size());
-            result[0] = potentialLabels.get(labelIndex); // new label
+	        long selectedLabel = Long.parseLong(potentialLabels.get(0));
+	        for (String potentialLabel : potentialLabels) {
+		        long parsedPotentialLabel = Long.parseLong(potentialLabel);
+		        if (parsedPotentialLabel < selectedLabel) {
+			        selectedLabel = parsedPotentialLabel;
+		        }
+	        }
+            result[0] = String.valueOf(selectedLabel); // new label
         }
 
         // set delta param value

--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/UndirectedCambridgeLPAReducer.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/cd/UndirectedCambridgeLPAReducer.java
@@ -112,13 +112,13 @@ public class UndirectedCambridgeLPAReducer extends MapReduceBase implements Redu
 
         // select the smallest potential label to make output deterministic
         if(potentialLabels.size() > 1) {
-	        long selectedLabel = Long.parseLong(potentialLabels.get(0));
-	        for (String potentialLabel : potentialLabels) {
-		        long parsedPotentialLabel = Long.parseLong(potentialLabel);
-		        if (parsedPotentialLabel < selectedLabel) {
-			        selectedLabel = parsedPotentialLabel;
-		        }
-	        }
+            long selectedLabel = Long.parseLong(potentialLabels.get(0));
+            for (String potentialLabel : potentialLabels) {
+                long parsedPotentialLabel = Long.parseLong(potentialLabel);
+                if (parsedPotentialLabel < selectedLabel) {
+                    selectedLabel = parsedPotentialLabel;
+                }
+            }
             result[0] = String.valueOf(selectedLabel); // new label
         }
 

--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/evo/DirectedForestFireModelMap.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/evo/DirectedForestFireModelMap.java
@@ -62,7 +62,7 @@ public class DirectedForestFireModelMap extends MapReduceBase implements Mapper<
             for(LongWritable id : this.ambassadors.get(new LongWritable(Long.parseLong(node.getId()))))
                 edges.add(new Edge(node.getId(), id.toString()));
             node.setInEdges(edges);
-        } else { // check if potential ambassador n send to new vertex
+        } else if (Long.parseLong(node.getId()) < this.maxID) { // check if potential ambassador n send to new vertex
             Set<LongWritable> edges = new HashSet<LongWritable>();
             for(Edge out : node.getOutEdges())
                 edges.add(new LongWritable(Long.parseLong(out.getDest())));

--- a/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/evo/UndirectedForestFireModelMap.java
+++ b/platforms/mapreducev2/src/main/java/nl/tudelft/graphalytics/mapreducev2/evo/UndirectedForestFireModelMap.java
@@ -62,7 +62,7 @@ public class UndirectedForestFireModelMap extends MapReduceBase implements Mappe
             for(LongWritable id : this.ambassadors.get(new LongWritable(Long.parseLong(node.getId()))))
                 edges.add(new Edge(node.getId(), id.toString()));
             node.setEdges(edges);
-        } else { // check if potential ambassador n send to new vertex
+        } else if (Long.parseLong(node.getId()) < this.maxID) { // check if potential ambassador n send to new vertex
             for(Edge edge : node.getEdges()) {
                 long neighbour = Long.parseLong(edge.getDest());
                 if(ambassadors.containsKey(new LongWritable(neighbour))) {


### PR DESCRIPTION
- Made community detection algorithm deterministic in case of ties (implementations on other platforms already used this deterministic tie breaker).
- Altered forest fire model implementation to ignore the newly created vertices when selecting links to follow. Not all platforms support alteration of the graph structure during algorithm execution, so to introduce consistency all platforms should "pretend" that the new vertices do not exist until after the algorithm has finished.

Closes #48 