### PR TITLE
[GraphX] Add scalatest maven plugin to enable automated testing

### DIFF
--- a/platforms/graphx/pom.xml
+++ b/platforms/graphx/pom.xml
@@ -112,6 +112,25 @@
 					</transformers>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.scalatest</groupId>
+				<artifactId>scalatest-maven-plugin</artifactId>
+				<version>1.0</version>
+				<configuration>
+					<reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+					<junitxml>.</junitxml>
+					<filereports>GraphalyticsGraphXTestSuite.txt</filereports>
+				</configuration>
+				<executions>
+					<execution>
+						<id>test</id>
+						<goals>
+							<goal>test</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Somewhere in the build process rehaul the automated execution of GraphX tests stopped working. This PR adds a maven plugin to run Scala unit tests.